### PR TITLE
[SGP-22256] feat: add Django 3.0,3.1,3.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-        - image: kaikuehne/pyenv:alpine3.10
+        - image: cimg/python:3.7
           environment:
             PATH: "/root/pyenv/bin:/root/pyenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
             PYENV_ROOT: "/root/pyenv"
@@ -18,11 +18,10 @@ jobs:
             command: |
                 pyenv --version
                 pyenv install --list
-                pyenv install --keep --skip-existing 2.7.16
                 pyenv install --keep --skip-existing 3.7.4
                 pyenv rehash
                 pyenv versions
-                pyenv local  2.7.16 3.7.4
+                pyenv local 3.7.4
                 pip install --upgrade pip
                 pip install tox tox-pyenv
             shell: /bin/bash

--- a/currency_rates/management/commands/load_currencies.py
+++ b/currency_rates/management/commands/load_currencies.py
@@ -1,5 +1,5 @@
 import json
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 from django.core.management.base import BaseCommand
 from currency_rates.models import Currency
 

--- a/currency_rates/management/commands/load_rates.py
+++ b/currency_rates/management/commands/load_rates.py
@@ -1,5 +1,5 @@
 import json
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 import datetime
 from decimal import Decimal
 from django.core.management.base import BaseCommand

--- a/currency_rates/models.py
+++ b/currency_rates/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import datetime
 from django.db import models
 from django.conf import settings
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import gettext_lazy as _
 
 
@@ -22,7 +21,6 @@ def default_currency():
     return None
 
 
-@python_2_unicode_compatible
 class Currency(models.Model):
     code = models.CharField(_('Code'), max_length=3, primary_key=True)
     name = models.CharField(_('Name'), max_length=50)
@@ -71,7 +69,6 @@ class Currency(models.Model):
         return result
 
 
-@python_2_unicode_compatible
 class ExchangeRate(models.Model):
     currency = models.ForeignKey(Currency, related_name='rates', on_delete=models.CASCADE)
     date = models.DateField(_('Date'), default=datetime.date.today)

--- a/currency_rates/tests.py
+++ b/currency_rates/tests.py
@@ -4,7 +4,6 @@ import time
 import json
 from django.test import TestCase
 from django.test.utils import override_settings
-from six import text_type
 
 from currency_rates.models import Currency, ExchangeRate, default_currency
 from currency_rates.management.commands import load_currencies, load_rates
@@ -16,7 +15,7 @@ class CurrencyModelTest(TestCase):
 
         currency = Currency(code='EUR', name="Euro")
 
-        self.assertEqual(text_type(currency), 'EUR')
+        self.assertEqual(str(currency), 'EUR')
 
     def test_no_rates(self):
 
@@ -78,7 +77,7 @@ class RateModelTest(TestCase):
         rate = ExchangeRate.objects.create(currency=currency,
                                      rate=Decimal("2.00"))
 
-        self.assertEqual(text_type(rate), 'EUR 2.00')
+        self.assertEqual(str(rate), 'EUR 2.00')
 
 
 class DefaultCurrencyTest(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 coverage
 mock==0.8.0
-six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,4 @@ setup(
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content'
     ],
-    install_requires=[
-          'six',
-    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py27-django{111},
-    py37-django{111,20,21,22},
+    py37-django{30,31,32},
 
 [testenv]
 setenv =
@@ -10,10 +9,9 @@ passenv =
     OPENEXCHANGERATES_APP_ID
 deps =
     -r{toxinidir}/requirements.txt
-    django111: Django >=1.11, <2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 commands =
     coverage run --branch --source=currency_rates example/manage.py test currency_rates
 


### PR DESCRIPTION
BREAKING CHANGE: Remove Django 1.X and 2.X compatibility

This PR adds compatibility with Django 3.X, in preparation for the upgrade to Django 3.

### Manual QA

1. Checkout the branch from https://github.com/startupgrind/Platform/pull/10810, which pins `django-currency-rates` to this commit.
2. Run `BEVY_VARIATION=demo docker-compose -f docker-compose-lts.yml up` (you may also need to add the `--build` flag). When the app starts, you should not see any errors relating to this package.